### PR TITLE
Add a description key to Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "bevy_landmass"
 version = "0.1.0"
 edition = "2021"
 
+description = "A plugin for Bevy to handle navigation of AI characters."
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Missed this when adding the pre-release stuff.