### PR TITLE
Make nav meshes assets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ categories = ["game-development"]
 keywords = ["navigation", "pathfinding", "avoidance", "landmass", "bevy"]
 
 [dependencies]
-bevy = { version = "0.12.0", default-features = false }
+bevy = { version = "0.12.0", default-features = false, features = [
+  "bevy_asset",
+] }
 glam = "0.24.2"
 landmass = "0.2.0"
 


### PR DESCRIPTION
Fixes #13.

Now users can create the islands at startup, then load their nav meshes asynchronously. Users no longer need to make their own async management.