### PR TITLE
Fix the nav mesh getting reset every frame.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ fn sync_island_nav_mesh(
       None => true,
       Some((current_transform, current_nav_mesh)) => {
         current_transform != island_transform
-          || Arc::ptr_eq(&current_nav_mesh, &island_nav_mesh.0)
+          || !Arc::ptr_eq(&current_nav_mesh, &island_nav_mesh.0)
       }
     };
 


### PR DESCRIPTION
I accidentally negated this, so an island would keep gettings its nav mesh set **until** a different nav mesh is set, at which point it would stop getting set.

Now it works how you'd expect!