### PR TITLE
Create a basic mod debug for bevy_landmass.

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,12 @@
+pub use landmass::debug::*;
+
+/// Draws all parts of `archipelago` to `debug_drawer`.
+pub fn draw_archipelago_debug(
+  archipelago: &crate::Archipelago,
+  debug_drawer: &mut impl DebugDrawer,
+) {
+  landmass::debug::draw_archipelago_debug(
+    &archipelago.archipelago,
+    debug_drawer,
+  )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub use landmass::Vec3;
 
 pub use landmass_structs::*;
 
+pub mod debug;
+
 #[cfg(feature = "mesh-utils")]
 pub mod nav_mesh;
 


### PR DESCRIPTION
This mainly allows users to call the debug drawer for the internal archipelago. It also re-exports the landmass debug stuff.